### PR TITLE
feat: add about link and enhance localization in ETF calculator

### DIFF
--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "서비스 소개 | ETF 프리미엄 분석 플랫폼",
+  description:
+    "한국 상장 미국 ETF(TIGER, KODEX, ACE)의 프리미엄·NAV 분석, 매수/매도 신호, 프리미엄 추이·전략 시뮬레이션을 제공하는 무료 분석 도구입니다.",
+  openGraph: {
+    title: "서비스 소개 | ETF 프리미엄 분석 플랫폼",
+    description:
+      "한국 상장 미국 ETF의 프리미엄·NAV 분석, 매수/매도 신호, 프리미엄 추이·전략 시뮬레이션을 제공하는 무료 분석 도구입니다.",
+  },
+}
+
+export default function AboutLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return <>{children}</>
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import Link from "next/link"
+import { ChevronLeft } from "lucide-react"
+
+export default function AboutPage() {
+  const t = useTranslations("about")
+
+  return (
+    <main className="min-h-screen bg-background py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 mb-6"
+          aria-label={t("backToHome")}
+        >
+          <ChevronLeft className="w-4 h-4" />
+          {t("backToHome")}
+        </Link>
+
+        <article className="prose prose-gray dark:prose-invert max-w-none">
+          <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl mb-2">
+            {t("title")}
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 text-base mb-8">
+            {t("description")}
+          </p>
+
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">
+              {t("sectionWhatTitle")}
+            </h2>
+            <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
+              {t("sectionWhatContent")}
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">
+              {t("sectionFeaturesTitle")}
+            </h2>
+            <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+              <li>{t("featurePremium")}</li>
+              <li>{t("featureSignal")}</li>
+              <li>{t("featureTrend")}</li>
+              <li>{t("featureStrategy")}</li>
+              <li>{t("featureCompare")}</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">
+              {t("sectionTargetTitle")}
+            </h2>
+            <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
+              {t("sectionTargetContent")}
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">
+              {t("sectionDisclaimerTitle")}
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
+              {t("sectionDisclaimerContent")}
+            </p>
+          </section>
+        </article>
+      </div>
+    </main>
+  )
+}

--- a/components/etf-calculator.tsx
+++ b/components/etf-calculator.tsx
@@ -3,6 +3,7 @@
 import type React from "react";
 import { useState, useRef, useEffect } from "react";
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 import {
   Calculator,
   TrendingUp,
@@ -346,10 +347,17 @@ export function EtfCalculator() {
 
       {/* Page Title - 좌측, i18n·테마 우측 / 모바일에서도 between */}
       <div className="relative flex flex-row justify-between items-start gap-3 pb-2">
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 flex flex-wrap items-baseline gap-x-4 gap-y-1">
           <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl">
             {pageTitle}
           </h1>
+          <Link
+            href="/about"
+            className="text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+            aria-label={t("headerServiceDescription")}
+          >
+            {t("headerServiceDescription")}
+          </Link>
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <ThemeToggle />

--- a/messages/en.json
+++ b/messages/en.json
@@ -93,5 +93,23 @@
   "themeDark": "Dark",
   "themeSystem": "System",
   "themeToggleLabel": "Change theme",
-  "themeToggleClickHint": "Click to cycle theme"
+  "themeToggleClickHint": "Click to cycle theme",
+  "headerServiceDescription": "About this service",
+  "about": {
+    "title": "About this service",
+    "description": "A free analysis tool for Korea-listed US ETFs: premium/NAV analysis, buy/sell signals, premium trend charts, and strategy simulation.",
+    "backToHome": "Back to home",
+    "sectionWhatTitle": "What is this service?",
+    "sectionWhatContent": "This platform analyzes real-time premium (discount/premium to NAV) for US index-tracking ETFs listed on the Korean exchange (e.g. TIGER US Nasdaq 100, KODEX US S&P 500, ACE US Semiconductor). It provides buy/sell/neutral signals based on iNAV (indicative NAV) and uses market data from NAVER Finance. You can also view premium history charts, run strategy simulations, and compare ETFs that track the same index.",
+    "sectionFeaturesTitle": "Features",
+    "featurePremium": "Real-time premium analysis and iNAV-based fair value estimate",
+    "featureSignal": "Buy/sell/neutral signals by premium band",
+    "featureTrend": "Premium history chart with cheap/expensive zone interpretation",
+    "featureStrategy": "DCA and lump-sum strategy simulation",
+    "featureCompare": "Compare NAV, iNAV, and premium across same-index ETFs",
+    "sectionTargetTitle": "Who is it for?",
+    "sectionTargetContent": "Useful for investors trading US index ETFs, or anyone looking to time entries by premium level or compare same-index ETFs. Information is for reference only; investment decisions are your own responsibility.",
+    "sectionDisclaimerTitle": "Disclaimer",
+    "sectionDisclaimerContent": "Figures and signals on this service are for reference only and do not constitute investment advice or predictions. iNAV and premium are estimates based on prior NAV, index, and FX data and may differ from official NAV and market conditions. All investment decisions are your own responsibility."
+  }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -93,5 +93,23 @@
   "themeDark": "다크",
   "themeSystem": "시스템",
   "themeToggleLabel": "테마 변경",
-  "themeToggleClickHint": "클릭 시 순서대로 전환"
+  "themeToggleClickHint": "클릭 시 순서대로 전환",
+  "headerServiceDescription": "서비스 소개",
+  "about": {
+    "title": "서비스 소개",
+    "description": "한국 상장 미국 ETF의 프리미엄·NAV 분석, 매수/매도 신호, 프리미엄 추이·전략 시뮬레이션을 제공하는 무료 분석 도구입니다.",
+    "backToHome": "메인으로 돌아가기",
+    "sectionWhatTitle": "이 서비스는 무엇인가요?",
+    "sectionWhatContent": "본 플랫폼은 한국 거래소에 상장된 미국 지수 추종 ETF(예: TIGER 미국나스닥100, KODEX 미국S&P500, ACE 미국반도체 등)의 실시간 프리미엄(괴리율)을 분석하고, iNAV(실시간 추정 순자산가치) 기준 매수/매도 신호를 제공합니다. 시세 데이터는 NAVER 금융을 통해 조회할 수 있으며, 프리미엄 추이 차트·전략 시뮬레이션·동일 지수 ETF 비교 기능을 함께 제공합니다.",
+    "sectionFeaturesTitle": "제공 기능",
+    "featurePremium": "실시간 프리미엄(괴리율) 분석 및 iNAV 기반 추정 가격 계산",
+    "featureSignal": "프리미엄 구간별 매수/매도/관망 신호 안내",
+    "featureTrend": "과거 프리미엄 추이 차트 및 저평가·고평가 구간 해석",
+    "featureStrategy": "정액/정량 매매 전략 시뮬레이션",
+    "featureCompare": "같은 지수 추종 ETF 간 NAV·iNAV·프리미엄 비교",
+    "sectionTargetTitle": "누구를 위한 서비스인가요?",
+    "sectionTargetContent": "미국 지수 ETF를 거래하는 투자자, 프리미엄을 고려한 매매 타이밍을 찾고 싶은 분, 또는 동일 지수 ETF 중 우대 조건을 비교하고 싶은 분에게 유용합니다. 참고용 정보이며, 투자 판단은 본인 책임입니다.",
+    "sectionDisclaimerTitle": "면책 조항",
+    "sectionDisclaimerContent": "본 서비스의 수치와 신호는 참고용이며, 투자 권유나 예측을 목적으로 하지 않습니다. iNAV·프리미엄은 전일 NAV·지수·환율 등을 기반으로 한 추정값이며, 실제 공시 NAV·시장 상황과 다를 수 있습니다. 투자 결정은 반드시 본인의 판단과 책임 하에 이루어져야 합니다."
+  }
 }


### PR DESCRIPTION
- Introduced a new link to the "About this service" page in the ETF calculator for better user navigation.
- Expanded localization files to include new strings for the about section in both English and Korean, providing detailed descriptions of the service and its features.